### PR TITLE
Add the option to convert WordPress trunk access from SVN to Git

### DIFF
--- a/bin/develop_git
+++ b/bin/develop_git
@@ -1,0 +1,44 @@
+#!/bin/bash
+#
+# A script to convert the included develop.svn.wordpress.org repository into
+# the git mirror, develop.git.wordpress.org.
+
+set -e
+
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+	DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+	SOURCE="$(readlink "$SOURCE")"
+	[[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+DIR=`dirname $DIR`
+
+if [[ $USER != 'vagrant' ]]; then
+	echo "Please run inside Vagrant"
+	exit 1
+fi
+
+cd ${DIR}/public_html
+
+if [[ -e .git ]]; then
+	echo "Repo has already been converted to Git"
+	exit 1
+fi
+
+echo "Converting WordPress develop from SVN to GIT"
+
+echo "Rename .svn to .svn-backup"
+mv .svn .svn-backup
+
+git clone --no-checkout git://develop.git.wordpress.org/ /tmp/wp-git
+cd /tmp/wp-git
+git reset -q .
+cd ${DIR}/public_html
+
+echo "Moving .git dir to ${DIR}/public_html"
+mv /tmp/wp-git/.git .git
+git config core.fileMode false
+git config diff.noprefix true
+
+echo "Done"

--- a/provision/vvv-init.sh
+++ b/provision/vvv-init.sh
@@ -27,7 +27,15 @@ if [[ ! -f "${VVV_PATH_TO_SITE}/public_html/src/wp-load.php" ]]; then
 else
   cd "${VVV_PATH_TO_SITE}/public_html"
   echo "Updating WordPress trunk. See https://develop.svn.wordpress.org/trunk"
-  noroot svn up
+  if [[ -e .svn ]]; then
+    noroot svn up
+  else
+    if [[ $(noroot git rev-parse --abbrev-ref HEAD) == 'master' ]]; then
+      noroot git pull --no-edit git://develop.git.wordpress.org/ master
+    else
+      echo "Skip auto git pull on develop.git.wordpress.org since not on master branch"
+    fi
+  fi
   noroot npm install &>/dev/null
   noroot grunt
 fi


### PR DESCRIPTION
I've had a go at creating the option to switch from SVN to Git that I think resolves Varying-Vagrant-Vagrants/VVV#1554 and restores the conversion behaviour that was available in [the deprecated `wordpress-develop` template](https://github.com/Varying-Vagrant-Vagrants/vvv-wordpress-develop).

One difference in the provisioning here is that this version doesn't create a symlink to `bin/develop_git` in `/home/vagrant/bin/`, because this template may be used to provision multiple sites. For each site, you can `vagrant ssh -c /srv/www/<site-directory>/bin/develop_git` to convert that site from SVN to Git.

I've tested it by having either or both of these site configurations in my `vvv-custom.yml`:

```
  # The wordpress-develop configuration is useful for contributing to WordPress.
  wordpress-develop:
    repo: https://github.com/tobiasziegler/custom-site-template-develop.git
    branch: develop-git
    hosts:
      - src.wordpress-develop.test
      - build.wordpress-develop.test
  
  # This is to test my changes to the default wordpress-develop template
  git-develop:
    repo: https://github.com/tobiasziegler/custom-site-template-develop.git
    branch: develop-git
    hosts:
      - git-develop.test
```
