### PR TITLE
no optional packages with npm

### DIFF
--- a/provision/vvv-init.sh
+++ b/provision/vvv-init.sh
@@ -34,7 +34,7 @@ if [[ ! -f "${VVV_PATH_TO_SITE}/public_html/src/wp-load.php" ]]; then
   noroot svn checkout "https://develop.svn.wordpress.org/trunk/" "${VVV_PATH_TO_SITE}/public_html"
   cd "${VVV_PATH_TO_SITE}/public_html"
   echo "Running npm install"
-  noroot npm install
+  noroot npm install --no-optional
 else
   cd "${VVV_PATH_TO_SITE}/public_html"
   echo "Updating WordPress trunk. See https://develop.svn.wordpress.org/trunk"
@@ -50,7 +50,7 @@ else
     fi
   fi
   echo "Running npm install"
-  noroot npm install
+  noroot npm install --no-optional
   echo "Running grunt"
   noroot grunt
 fi


### PR DESCRIPTION
Fix https://github.com/Varying-Vagrant-Vagrants/VVV/issues/1801

fsevents module on node is only for OSX https://github.com/npm/npm/issues/14042 so because we cannot change the package.json file in wordpress in the meantime we can disable in npm to download optionable packages on provision (this can still do it manually)