### PR TITLE
Fix #1868: Grunt/Webpack output on template-develop in a file 

### DIFF
--- a/provision/vvv-init.sh
+++ b/provision/vvv-init.sh
@@ -54,7 +54,7 @@ else
     noroot npm install --no-optional
   fi
   echo "Running grunt"
-  echo " Check the Grunt/Webpack output for Trunk at VVV/log/provisioners/${date_time}/provisioner-${NAME}-grunt.log"
+  echo " Check the Grunt/Webpack output for Trunk at VVV/log/provisioners/${date_time}/provisioner-${VVV_SITE_NAME}-grunt.log"
   noroot grunt > $logfile 2>&1 
 fi
 

--- a/provision/vvv-init.sh
+++ b/provision/vvv-init.sh
@@ -20,6 +20,10 @@ noroot mkdir -p ${VVV_PATH_TO_SITE}/log
 noroot touch ${VVV_PATH_TO_SITE}/log/nginx-error.log
 noroot touch ${VVV_PATH_TO_SITE}/log/nginx-access.log
 
+date_time=`cat /vagrant/provisioned_at`
+logfolder="/var/log/provisioners/${date_time}"
+logfile="${logfolder}/provisioner-${NAME}-grunt.log"
+
 # Install and configure the latest stable version of WordPress
 if [[ ! -f "${VVV_PATH_TO_SITE}/public_html/src/wp-load.php" ]]; then
   echo "Checking out WordPress trunk. See https://develop.svn.wordpress.org/trunk"
@@ -50,7 +54,7 @@ else
     noroot npm install --no-optional
   fi
   echo "Running grunt"
-  noroot grunt
+  noroot grunt > $logfile 2>&1 
 fi
 
 if [[ ! -f "${VVV_PATH_TO_SITE}/public_html/wp-config.php" ]]; then
@@ -96,7 +100,7 @@ echo "Checking for WordPress build"
 if [[ ! -d "${VVV_PATH_TO_SITE}/public_html/build" ]]; then
   echo "Initializing grunt... This may take a few moments."
   cd "${VVV_PATH_TO_SITE}/public_html/"
-  noroot grunt
+  noroot grunt > $logfile 2>&1 
   echo "Grunt initialized."
 fi
 echo "Checking mu-plugins folder"

--- a/provision/vvv-init.sh
+++ b/provision/vvv-init.sh
@@ -56,6 +56,10 @@ else
   echo "Running grunt"
   echo " Check the Grunt/Webpack output for Trunk at VVV/log/provisioners/${date_time}/provisioner-${VVV_SITE_NAME}-grunt.log"
   noroot grunt > $logfile 2>&1 
+  if [ $? -ne 0 ]; then
+     echo "Grunt exited with an error, last 10 lines of log:"
+     tail -10 $logfile
+  fi
 fi
 
 if [[ ! -f "${VVV_PATH_TO_SITE}/public_html/wp-config.php" ]]; then

--- a/provision/vvv-init.sh
+++ b/provision/vvv-init.sh
@@ -22,7 +22,7 @@ noroot touch ${VVV_PATH_TO_SITE}/log/nginx-access.log
 
 date_time=`cat /vagrant/provisioned_at`
 logfolder="/var/log/provisioners/${date_time}"
-logfile="${logfolder}/provisioner-${NAME}-grunt.log"
+logfile="${logfolder}/provisioner-${VVV_SITE_NAME}-grunt.log"
 
 # Install and configure the latest stable version of WordPress
 if [[ ! -f "${VVV_PATH_TO_SITE}/public_html/src/wp-load.php" ]]; then

--- a/provision/vvv-init.sh
+++ b/provision/vvv-init.sh
@@ -54,6 +54,7 @@ else
     noroot npm install --no-optional
   fi
   echo "Running grunt"
+  echo " Check the Grunt/Webpack output for Trunk at VVV/log/provisioners/${date_time}/provisioner-${NAME}-grunt.log"
   noroot grunt > $logfile 2>&1 
 fi
 
@@ -100,6 +101,7 @@ echo "Checking for WordPress build"
 if [[ ! -d "${VVV_PATH_TO_SITE}/public_html/build" ]]; then
   echo "Initializing grunt... This may take a few moments."
   cd "${VVV_PATH_TO_SITE}/public_html/"
+  echo " Check the Grunt/Webpack output for Trunk Build at VVV/log/provisioners/${date_time}/provisioner-${NAME}-grunt.log"
   noroot grunt > $logfile 2>&1 
   echo "Grunt initialized."
 fi


### PR DESCRIPTION
This will move the output from the VVV one to a specific file as https://github.com/Varying-Vagrant-Vagrants/VVV/issues/1868.
Require a bit of testing.