### PR TITLE
Sets stricter bash execution on the main provisioner

### DIFF
--- a/provision/vvv-init.sh
+++ b/provision/vvv-init.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -eo pipefail
+
 echo "Custom Site Template Develop Provisioner - use this template for WP Core development. For client work, use the custom-site-template instead"
 
 DOMAIN=`get_primary_host "${VVV_SITE_NAME}".test`


### PR DESCRIPTION
This will need more testing than the previous one, it'll need to be tested with:

 - a fresh provision of a new site
 - that the end resulting WP install is functional
 - on an existing site
 - with a git version of the site