### PR TITLE
Fix #2033

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,17 @@ my-site:
     - my-site.test
 ```
 
+This settings will use as default SVN to download WordPress-develop but is possible to switch to git:
+
+```yaml
+my-site:
+  repo: https://github.com/Varying-Vagrant-Vagrants/custom-site-template-develop
+  hosts:
+    - my-site.test
+  custom:
+    vcs: git # using 'svn' will force this vcs
+```
+
 | Setting    | Value        |
 |------------|--------------|
 | Domain     | my-site.test |

--- a/provision/vvv-init.sh
+++ b/provision/vvv-init.sh
@@ -15,7 +15,7 @@ try_npm_install() {
     echo " * Removing the node modules folder"
     rm -rf node_modules
     echo " * Clearing npm cache"
-    noroot npm cache clean --force
+    noroot npm cache clean --force &> /dev/null
     echo " * Running npm install again"
     noroot npm install --no-optional
     echo " * Completed npm install command, check output for issues"

--- a/provision/vvv-init.sh
+++ b/provision/vvv-init.sh
@@ -6,12 +6,10 @@ try_npm_install() {
   echo " * Running npm install after svn up/git pull"
   # Grunt can crash because doesn't find a folder, the workaround is remove the node_modules folder and download all the dependencies again.
   # We create a file with the stderr output of NPM to check if there are errors, if yes we remove the folder and try again npm install.
-  noroot npm install --no-optional &> /tmp/dev-npm.txt
+  noroot npm install --no-optional
   echo " * Checking npm install result"
-  if [ "$(grep -c "^$1" /tmp/dev-npm.txt)" -ge 1 ]; then
+  if [ $? -eq 0 ]; then
     echo " ! Issues encounteed, here's the output:"
-    cat /tmp/dev-npm.txt
-    rm /tmp/dev-npm.txt
     echo " * Removing the node modules folder"
     rm -rf node_modules
     echo " * Clearing npm cache"

--- a/provision/vvv-init.sh
+++ b/provision/vvv-init.sh
@@ -71,17 +71,15 @@ fi
 # Install and configure the latest stable version of WordPress
 echo " * Checking for WordPress Installs"
 VCS=$(get_config_value 'vcs' '')
-if [[ $VCS -eq '' ]]; then
-  if [[ ! -f "${VVV_PATH_TO_SITE}/public_html/.svn" ]] && [[ ! -f "${VVV_PATH_TO_SITE}/public_html/.git" ]]; then
-    VCS='svn'
-  fi
-  
-  if [[ -f "${VVV_PATH_TO_SITE}/public_html/.git" ]]; then
-    VCS='git'
+if [[ $VCS -eq "" ]]; then
+  if [[ -f "${VVV_PATH_TO_SITE}/public_html/.svn" ]]; then
+    VCS="svn"
+  elif [[ -f "${VVV_PATH_TO_SITE}/public_html/.git" ]]; then
+    VCS="git"
   fi
 fi
 
-if [[ $VCS -eq 'svn' ]]; then
+if [[ "${VCS}" = "svn" ]]; then
   if [[ ! -e .svn ]]; then
     echo " * Checking out WordPress trunk. See https://develop.svn.wordpress.org/trunk"
     noroot svn checkout "https://develop.svn.wordpress.org/trunk/" "${VVV_PATH_TO_SITE}/public_html"
@@ -93,7 +91,7 @@ if [[ $VCS -eq 'svn' ]]; then
   fi
 fi
 
-if [[ $VCS -eq 'git' ]]; then
+if [[ "${VCS}" = "git" ]]; then
     if [[ $(noroot git rev-parse --abbrev-ref HEAD) == 'master' ]]; then
       echo " * Running git pull --no-edit git://develop.git.wordpress.org/ master"
       noroot git pull --no-edit git://develop.git.wordpress.org/ master

--- a/provision/vvv-init.sh
+++ b/provision/vvv-init.sh
@@ -17,7 +17,7 @@ try_npm_install() {
     echo " * Clearing npm cache"
     noroot npm cache clean --force &> /dev/null
     echo " * Running npm install again"
-    noroot npm install --no-optional
+    noroot npm install --no-optional &> /tmp/dev-npm.txt
     echo " * Completed npm install command, check output for issues"
   fi
   echo " * Finished running npm install"

--- a/provision/vvv-init.sh
+++ b/provision/vvv-init.sh
@@ -145,7 +145,7 @@ echo " * Checking for WordPress build"
 if [[ ! -d "${VVV_PATH_TO_SITE}/public_html/build" ]]; then
   echo " * Initializing grunt... This may take a few moments."
   cd "${VVV_PATH_TO_SITE}/public_html/"
-  verify_grunt_exec
+  try_grunt_build
   echo " * Grunt initialized."
 fi
 

--- a/provision/vvv-init.sh
+++ b/provision/vvv-init.sh
@@ -94,7 +94,7 @@ fi
 if [[ "${VCS}" = "git" ]]; then
     if [[ ! -e .git ]]; then
         echo " * Checking out WordPress trunk. See https://develop.git.wordpress.org/"
-        noroot git clone git://develop.git.wordpress.org/
+        noroot git clone git://develop.git.wordpress.org/ .
     fi
     if [[ $(noroot git rev-parse --abbrev-ref HEAD) == 'master' ]]; then
       echo " * Running git pull --no-edit git://develop.git.wordpress.org/ master"

--- a/provision/vvv-init.sh
+++ b/provision/vvv-init.sh
@@ -28,7 +28,7 @@ try_grunt_build() {
   logfolder="/var/log/provisioners/${date_time}"
   gruntlogfile="${logfolder}/provisioner-${VVV_SITE_NAME}-grunt.log"
   echo " * Running grunt"
-  echo " * Check the Grunt/Webpack output for Trunk Build at VVV/log/provisioners/${date_time}/provisioner-${NAME}-grunt.log"
+  echo " * Check the Grunt/Webpack output for Trunk Build at VVV/log/provisioners/${date_time}/provisioner-${VVV_SITE_NAME}-grunt.log"
   noroot grunt > "${gruntlogfile}" 2>&1 
   if [ $? -ne 0 ]; then
      echo " ! Grunt exited with an error, these are the last 20 lines of the log:"

--- a/provision/vvv-init.sh
+++ b/provision/vvv-init.sh
@@ -71,19 +71,30 @@ fi
 
 # Install and configure the latest stable version of WordPress
 echo " * Checking for WordPress Installs"
-if [[ ! -f "${VVV_PATH_TO_SITE}/public_html/.svn" ]] && [[ ! -f "${VVV_PATH_TO_SITE}/public_html/.git" ]]; then
-  echo " * Checking out WordPress trunk. See https://develop.svn.wordpress.org/trunk"
-  noroot svn checkout "https://develop.svn.wordpress.org/trunk/" "${VVV_PATH_TO_SITE}/public_html"
-else
-  cd "${VVV_PATH_TO_SITE}/public_html"
-  echo " * Updating WordPress trunk. See https://develop.svn.wordpress.org/trunk"
-  if [[ -e .svn ]]; then
+VCS=$(get_config_value 'vcs' '')
+if [[ $VCS -eq '' ]]; then
+  if [[ ! -f "${VVV_PATH_TO_SITE}/public_html/.svn" ]] && [[ ! -f "${VVV_PATH_TO_SITE}/public_html/.git" ]]; then
+    VCS='svn'
+  fi
+  
+  if [[ -f "${VVV_PATH_TO_SITE}/public_html/.git" ]]; then
+    VCS='git'
+  fi
+fi
+
+if [[ $VCS -eq 'svn' ]]; then
+  if [[ ! -e .svn ]]; then
+    echo " * Checking out WordPress trunk. See https://develop.svn.wordpress.org/trunk"
+    noroot svn checkout "https://develop.svn.wordpress.org/trunk/" "${VVV_PATH_TO_SITE}/public_html"
+  else
+    cd "${VVV_PATH_TO_SITE}/public_html"
+    echo " * Updating WordPress trunk. See https://develop.svn.wordpress.org/trunk"
     echo " * Running svn up"
     noroot svn up
   fi
 fi
 
-if [[ -f "${VVV_PATH_TO_SITE}/public_html/.git" ]]; then
+if [[ $VCS -eq 'git' ]]; then
     if [[ $(noroot git rev-parse --abbrev-ref HEAD) == 'master' ]]; then
       echo " * Running git pull --no-edit git://develop.git.wordpress.org/ master"
       noroot git pull --no-edit git://develop.git.wordpress.org/ master

--- a/provision/vvv-init.sh
+++ b/provision/vvv-init.sh
@@ -20,10 +20,11 @@ try_npm_install() {
     noroot npm install --no-optional
     echo " * Completed npm install command, check output for issues"
   fi
-  echo " * Finished running npm install"
+    echo " * Finished running npm install"
 }
 
-verify_grunt_exec() {
+try_grunt_build() {
+  echo " * Running grunt"
   echo " * Check the Grunt/Webpack output for Trunk Build at VVV/log/provisioners/${date_time}/provisioner-${NAME}-grunt.log"
   noroot grunt > "${gruntlogfile}" 2>&1 
   if [ $? -ne 0 ]; then
@@ -72,7 +73,7 @@ logfolder="/var/log/provisioners/${date_time}"
 gruntlogfile="${logfolder}/provisioner-${VVV_SITE_NAME}-grunt.log"
 
 # Install and configure the latest stable version of WordPress
-echo " * Checking for WordPress SVN Installs"
+echo " * Checking for WordPress Installs"
 if [[ ! -f "${VVV_PATH_TO_SITE}/public_html/.svn" ]] && [[ ! -f "${VVV_PATH_TO_SITE}/public_html/.git" ]]; then
   echo " * Checking out WordPress trunk. See https://develop.svn.wordpress.org/trunk"
   noroot svn checkout "https://develop.svn.wordpress.org/trunk/" "${VVV_PATH_TO_SITE}/public_html"
@@ -97,8 +98,7 @@ fi
     
 cd "${VVV_PATH_TO_SITE}/public_html"
 try_npm_install
-echo " * Running grunt"
-verify_grunt_exec
+try_grunt_build
 
 if [[ ! -f "${VVV_PATH_TO_SITE}/public_html/wp-config.php" ]]; then
   cd "${VVV_PATH_TO_SITE}/public_html"

--- a/provision/vvv-init.sh
+++ b/provision/vvv-init.sh
@@ -20,7 +20,7 @@ try_npm_install() {
     noroot npm install --no-optional
     echo " * Completed npm install command, check output for issues"
   fi
-    echo " * Finished running npm install"
+  echo " * Finished running npm install"
 }
 
 try_grunt_build() {
@@ -88,11 +88,11 @@ fi
 
 if [[ -f "${VVV_PATH_TO_SITE}/public_html/.git" ]]; then
     if [[ $(noroot git rev-parse --abbrev-ref HEAD) == 'master' ]]; then
-    echo " * Running git pull --no-edit git://develop.git.wordpress.org/ master"
-    noroot git pull --no-edit git://develop.git.wordpress.org/ master
+      echo " * Running git pull --no-edit git://develop.git.wordpress.org/ master"
+      noroot git pull --no-edit git://develop.git.wordpress.org/ master
     else
-    echo " * Skipped auto git pull on develop.git.wordpress.org since you aren't on the master branch"
-    git fetch --all
+      echo " * Skipped auto git pull on develop.git.wordpress.org since you aren't on the master branch"
+      git fetch --all
     fi
 fi
     

--- a/provision/vvv-init.sh
+++ b/provision/vvv-init.sh
@@ -71,7 +71,7 @@ fi
 # Install and configure the latest stable version of WordPress
 echo " * Checking for WordPress Installs"
 VCS=$(get_config_value 'vcs' '')
-if [[ $VCS -eq "" ]]; then
+if [[ ! -z "${VCS}" ]]; then
   if [[ -f "${VVV_PATH_TO_SITE}/public_html/.svn" ]]; then
     VCS="svn"
   elif [[ -f "${VVV_PATH_TO_SITE}/public_html/.git" ]]; then

--- a/provision/vvv-init.sh
+++ b/provision/vvv-init.sh
@@ -5,7 +5,7 @@ set -eo pipefail
 try_npm_install() {
   echo " * Running npm install after svn up/git pull"
   # Grunt can crash because doesn't find a folder, the workaround is remove the node_modules folder and download all the dependencies again.
-  noroot npm install --no-optional &> /dev/null
+  npm_config_loglevel=error noroot npm install --no-optional
   echo " * Checking npm install result"
   if [ $? -eq 0 ]; then
     echo " ! Issues encounteed, here's the output:"
@@ -14,7 +14,7 @@ try_npm_install() {
     echo " * Clearing npm cache"
     noroot npm cache clean --force &> /dev/null
     echo " * Running npm install again"
-    noroot npm install --no-optional &> /dev/null
+    npm_config_loglevel=error noroot npm install --no-optional &> /dev/null
     echo " * Completed npm install command, check output for issues"
   fi
   echo " * Finished running npm install"

--- a/provision/vvv-init.sh
+++ b/provision/vvv-init.sh
@@ -2,6 +2,36 @@
 
 set -eo pipefail
 
+try_npm_install() {
+  echo " * Running npm install after svn up/git pull"
+  # Grunt can crash because doesn't find a folder, the workaround is remove the node_modules folder and download all the dependencies again.
+  # We create a file with the stderr output of NPM to check if there are errors, if yes we remove the folder and try again npm install.
+  noroot npm install --no-optional &> /tmp/dev-npm.txt
+  echo " * Checking npm install result"
+  if [ "$(grep -c "^$1" /tmp/dev-npm.txt)" -ge 1 ]; then
+    echo " ! Issues encounteed, here's the output:"
+    cat /tmp/dev-npm.txt
+    rm /tmp/dev-npm.txt
+    echo " * Removing the node modules folder"
+    rm -rf node_modules
+    echo " * Clearing npm cache"
+    noroot npm cache clean --force
+    echo " * Running npm install again"
+    noroot npm install --no-optional
+    echo " * Completed npm install command, check output for issues"
+  fi
+  echo " * Finished running npm install"
+}
+
+verify_grunt_exec() {
+  echo " * Check the Grunt/Webpack output for Trunk Build at VVV/log/provisioners/${date_time}/provisioner-${NAME}-grunt.log"
+  noroot grunt > "${gruntlogfile}" 2>&1 
+  if [ $? -ne 0 ]; then
+     echo " ! Grunt exited with an error, these are the last 20 lines of the log:"
+     tail -20 "${gruntlogfile}"
+  fi
+}
+
 echo " * Custom Site Template Develop Provisioner"
 echo "   - This template is great for contributing to WordPress Core!"
 echo "   - Not so much for building themes and plugins, or agency/client work"
@@ -42,54 +72,33 @@ logfolder="/var/log/provisioners/${date_time}"
 gruntlogfile="${logfolder}/provisioner-${VVV_SITE_NAME}-grunt.log"
 
 # Install and configure the latest stable version of WordPress
-echo " * Checking for WordPress Installs"
-if [[ ! -f "${VVV_PATH_TO_SITE}/public_html/src/wp-load.php" ]]; then
+echo " * Checking for WordPress SVN Installs"
+if [[ ! -f "${VVV_PATH_TO_SITE}/public_html/.svn" ]] && [[ ! -f "${VVV_PATH_TO_SITE}/public_html/.git" ]]; then
   echo " * Checking out WordPress trunk. See https://develop.svn.wordpress.org/trunk"
   noroot svn checkout "https://develop.svn.wordpress.org/trunk/" "${VVV_PATH_TO_SITE}/public_html"
-  cd "${VVV_PATH_TO_SITE}/public_html"
-  echo " * Running npm install after svn checkout"
-  noroot npm install --no-optional
-  echo " * Finished npm install"
 else
   cd "${VVV_PATH_TO_SITE}/public_html"
   echo " * Updating WordPress trunk. See https://develop.svn.wordpress.org/trunk"
   if [[ -e .svn ]]; then
     echo " * Running svn up"
     noroot svn up
-  else
-    if [[ $(noroot git rev-parse --abbrev-ref HEAD) == 'master' ]]; then
-      echo " * Running git pull --no-edit git://develop.git.wordpress.org/ master"
-      noroot git pull --no-edit git://develop.git.wordpress.org/ master
-    else
-      echo " * Skipped auto git pull on develop.git.wordpress.org since you aren't on the master branch"
-    fi
-  fi
-  echo " * Running npm install after svn up/git pull"
-  # Grunt can crash because doesn't find a folder, the workaround is remove the node_modules folder and download all the dependencies again.
-  # We create a file with the stderr output of NPM to check if there are errors, if yes we remove the folder and try again npm install.
-  noroot npm install --no-optional &> /tmp/dev-npm.txt
-  echo " * Checking npm install result"
-  if [ "$(grep -c "^$1" /tmp/dev-npm.txt)" -ge 1 ]; then
-    echo " ! Issues encounteed, here's the output:"
-    cat /tmp/dev-npm.txt
-    rm /tmp/dev-npm.txt
-    echo " * Removing the node modules folder"
-    rm -rf node_modules
-    echo " * Clearing npm cache"
-    noroot npm cache clean --force
-    echo " * Running npm install again"
-    noroot npm install --no-optional
-    echo " * Completed npm install command, check output for issues"
-  fi
-  echo " * Finished running npm install"
-  echo " * Running grunt"
-  echo " * Check the Grunt/Webpack output for Trunk at VVV/log/provisioners/${date_time}/provisioner-${VVV_SITE_NAME}-grunt.log"
-  noroot grunt > "${gruntlogfile}" 2>&1 
-  if [ $? -ne 0 ]; then
-     echo " ! Grunt exited with an error, these are the last 20 lines of the log:"
-     tail -20 "${gruntlogfile}"
   fi
 fi
+
+if [[ -f "${VVV_PATH_TO_SITE}/public_html/.git" ]]; then
+    if [[ $(noroot git rev-parse --abbrev-ref HEAD) == 'master' ]]; then
+    echo " * Running git pull --no-edit git://develop.git.wordpress.org/ master"
+    noroot git pull --no-edit git://develop.git.wordpress.org/ master
+    else
+    echo " * Skipped auto git pull on develop.git.wordpress.org since you aren't on the master branch"
+    git fetch --all
+    fi
+fi
+    
+cd "${VVV_PATH_TO_SITE}/public_html"
+try_npm_install
+echo " * Running grunt"
+verify_grunt_exec
 
 if [[ ! -f "${VVV_PATH_TO_SITE}/public_html/wp-config.php" ]]; then
   cd "${VVV_PATH_TO_SITE}/public_html"
@@ -136,14 +145,10 @@ echo " * Checking for WordPress build"
 if [[ ! -d "${VVV_PATH_TO_SITE}/public_html/build" ]]; then
   echo " * Initializing grunt... This may take a few moments."
   cd "${VVV_PATH_TO_SITE}/public_html/"
-  echo " * Check the Grunt/Webpack output for Trunk Build at VVV/log/provisioners/${date_time}/provisioner-${NAME}-grunt.log"
-  noroot grunt > "${gruntlogfile}" 2>&1 
-  if [ $? -ne 0 ]; then
-     echo " ! Grunt exited with an error, these are the last 20 lines of the log:"
-     tail -20 "${gruntlogfile}"
-  fi
+  verify_grunt_exec
   echo " * Grunt initialized."
 fi
+
 echo " * Checking mu-plugins folder"
 noroot mkdir -p "${VVV_PATH_TO_SITE}/public_html/src/wp-content/mu-plugins" "${VVV_PATH_TO_SITE}/public_html/build/wp-content/mu-plugins"
 

--- a/provision/vvv-init.sh
+++ b/provision/vvv-init.sh
@@ -17,7 +17,7 @@ try_npm_install() {
     echo " * Clearing npm cache"
     noroot npm cache clean --force &> /dev/null
     echo " * Running npm install again"
-    noroot npm install --no-optional &> /tmp/dev-npm.txt
+    noroot npm install --no-optional &> /dev/null
     echo " * Completed npm install command, check output for issues"
   fi
   echo " * Finished running npm install"

--- a/provision/vvv-init.sh
+++ b/provision/vvv-init.sh
@@ -79,12 +79,12 @@ if [[ ! -z "${VCS}" ]]; then
   fi
 fi
 
+cd "${VVV_PATH_TO_SITE}/public_html"
 if [[ "${VCS}" = "svn" ]]; then
   if [[ ! -e .svn ]]; then
     echo " * Checking out WordPress trunk. See https://develop.svn.wordpress.org/trunk"
     noroot svn checkout "https://develop.svn.wordpress.org/trunk/" "${VVV_PATH_TO_SITE}/public_html"
   else
-    cd "${VVV_PATH_TO_SITE}/public_html"
     echo " * Updating WordPress trunk. See https://develop.svn.wordpress.org/trunk"
     echo " * Running svn up"
     noroot svn up
@@ -92,12 +92,16 @@ if [[ "${VCS}" = "svn" ]]; then
 fi
 
 if [[ "${VCS}" = "git" ]]; then
+    if [[ ! -e .git ]]; then
+        echo " * Checking out WordPress trunk. See https://develop.git.wordpress.org/"
+        noroot git clone git://develop.git.wordpress.org/
+    fi
     if [[ $(noroot git rev-parse --abbrev-ref HEAD) == 'master' ]]; then
       echo " * Running git pull --no-edit git://develop.git.wordpress.org/ master"
       noroot git pull --no-edit git://develop.git.wordpress.org/ master
     else
       echo " * Skipped auto git pull on develop.git.wordpress.org since you aren't on the master branch"
-      git fetch --all
+      noroot git fetch --all
     fi
 fi
     

--- a/provision/vvv-init.sh
+++ b/provision/vvv-init.sh
@@ -5,8 +5,7 @@ set -eo pipefail
 try_npm_install() {
   echo " * Running npm install after svn up/git pull"
   # Grunt can crash because doesn't find a folder, the workaround is remove the node_modules folder and download all the dependencies again.
-  # We create a file with the stderr output of NPM to check if there are errors, if yes we remove the folder and try again npm install.
-  noroot npm install --no-optional
+  noroot npm install --no-optional &> /dev/null
   echo " * Checking npm install result"
   if [ $? -eq 0 ]; then
     echo " ! Issues encounteed, here's the output:"

--- a/provision/vvv-init.sh
+++ b/provision/vvv-init.sh
@@ -24,6 +24,9 @@ try_npm_install() {
 }
 
 try_grunt_build() {
+  date_time=$(cat /vagrant/provisioned_at)
+  logfolder="/var/log/provisioners/${date_time}"
+  gruntlogfile="${logfolder}/provisioner-${VVV_SITE_NAME}-grunt.log"
   echo " * Running grunt"
   echo " * Check the Grunt/Webpack output for Trunk Build at VVV/log/provisioners/${date_time}/provisioner-${NAME}-grunt.log"
   noroot grunt > "${gruntlogfile}" 2>&1 
@@ -67,10 +70,6 @@ else
   echo " * Using the default vvv-nginx-default.conf, to customize, create a vvv-nginx-custom.conf"
   cp -f "${VVV_PATH_TO_SITE}/provision/vvv-nginx-default.conf" "${VVV_PATH_TO_SITE}/provision/vvv-nginx.conf"
 fi
-
-date_time=$(cat /vagrant/provisioned_at)
-logfolder="/var/log/provisioners/${date_time}"
-gruntlogfile="${logfolder}/provisioner-${VVV_SITE_NAME}-grunt.log"
 
 # Install and configure the latest stable version of WordPress
 echo " * Checking for WordPress Installs"


### PR DESCRIPTION
Ref: https://github.com/Varying-Vagrant-Vagrants/VVV/issues/2033
About:

* move grunt webpack and npm installs into their own bash functions to reduce duplication, try_npm_install/etc perhaps? **DONE**
* double check some of the conditionals, do we really need to check for wp-load.php to see if the svn checkout has been done? Couldn't we check for a .svn folder? **DONE with refactoring**
* Perhaps we can set the git vs svn thing in the config **DONE**
* I've forgotten what the build command to update the build folder is, it'd be nice if it said so in the output

