### PR TITLE
Warn if Custom site template develop vcs doesn't match an existing repo, fix #2121

### DIFF
--- a/provision/vvv-init.sh
+++ b/provision/vvv-init.sh
@@ -10,7 +10,7 @@ DB_NAME=${DB_NAME//[\\\/\.\<\>\:\"\'\|\?\!\*-]/}
 VCS=$(get_config_value 'vcs' '')
 
 if [[ -f "${VVV_PATH_TO_SITE}/public_html/.svn" && $VCS == "git" ]] || [[ "${VVV_PATH_TO_SITE}/public_html/.git" && $VCS == "svn" ]]; then
-  echo " * VCS doesn't match an existing repo, probably you set a different VCS compared to the one used by this template"
+  echo " * Warning: The VCS is set to ${VCS} but this doesn't match the existing repo, you need to manually migrate from svn to git or vice versa, VVV won't do it automatically to avoid data loss"
 fi
 
 if [[ -z "${VCS}" ]]; then

--- a/provision/vvv-init.sh
+++ b/provision/vvv-init.sh
@@ -10,7 +10,7 @@ DB_NAME=${DB_NAME//[\\\/\.\<\>\:\"\'\|\?\!\*-]/}
 VCS=$(get_config_value 'vcs' '')
 
 if [[ -f "${VVV_PATH_TO_SITE}/public_html/.svn" && $VCS == "git" ]] || [[ "${VVV_PATH_TO_SITE}/public_html/.git" && $VCS == "svn" ]]; then
-  echo " * VCS doesn't match an existing repo, probably you set a different VCS compraed to the one used by this template"
+  echo " * VCS doesn't match an existing repo, probably you set a different VCS compared to the one used by this template"
 fi
 
 if [[ -z "${VCS}" ]]; then

--- a/provision/vvv-init.sh
+++ b/provision/vvv-init.sh
@@ -9,7 +9,7 @@ DB_NAME=$(get_config_value 'db_name' "${VVV_SITE_NAME}")
 DB_NAME=${DB_NAME//[\\\/\.\<\>\:\"\'\|\?\!\*-]/}
 VCS=$(get_config_value 'vcs' '')
 
-if [[ -f "${VVV_PATH_TO_SITE}/public_html/.svn" && $VCS == "git" ]] || [[ "${VVV_PATH_TO_SITE}/public_html/.git" && $VCS == "svn" ]]; then
+if [[ -f "${VVV_PATH_TO_SITE}/public_html/.svn" && "${VCS}" == "git" ]] || [[ "${VVV_PATH_TO_SITE}/public_html/.git" && "${VCS}" == "svn" ]]; then
   echo " * Warning: The VCS is set to ${VCS} but this doesn't match the existing repo, you need to manually migrate from svn to git or vice versa, VVV won't do it automatically to avoid data loss"
 fi
 

--- a/provision/vvv-init.sh
+++ b/provision/vvv-init.sh
@@ -8,6 +8,11 @@ WP_TYPE=$(get_config_value 'wp_type' "single")
 DB_NAME=$(get_config_value 'db_name' "${VVV_SITE_NAME}")
 DB_NAME=${DB_NAME//[\\\/\.\<\>\:\"\'\|\?\!\*-]/}
 VCS=$(get_config_value 'vcs' '')
+
+if [[ -f "${VVV_PATH_TO_SITE}/public_html/.svn" && $VCS == "git" ]] || [[ "${VVV_PATH_TO_SITE}/public_html/.git" && $VCS == "svn" ]]; then
+  echo " * VCS doesn't match an existing repo, probably you set a different VCS compraed to the one used by this template"
+fi
+
 if [[ -z "${VCS}" ]]; then
   echo " * vcs value was not set in the config, checking for existing version control"
   if [[ -f "${VVV_PATH_TO_SITE}/public_html/.svn" ]]; then


### PR DESCRIPTION
Ref: https://github.com/Varying-Vagrant-Vagrants/VVV/issues/2121

* provision of this template using a specific vcs in the config.yml
* reprovisioning again but change that value from svn to git as example

This pr require some testing, I didn't add vvv_warn because this is a provisioner used also in old VVV versions.